### PR TITLE
Auto-add secrets file and slscrypt decryption helper to package.include

### DIFF
--- a/lib/addLibraries.js
+++ b/lib/addLibraries.js
@@ -9,6 +9,21 @@ module.exports = {
     fs.copySync(
       path.join(path.dirname(__dirname), 'dists'),
       this.serverless.config.servicePath);
+    if (!this.serverless.service) {
+      this.serverless.service = {
+        package: {
+          include: [],
+        },
+      };
+    } else if (!this.serverless.service.package) {
+      this.serverless.service.package = {
+        include: [],
+      };
+    } else if (!this.serverless.service.package.include) {
+      this.serverless.service.package.include = [];
+    }
+    this.serverless.service.package.include.push('slscrypt/*');
+    this.serverless.service.package.include.push('.serverless-secret.json');
     return BbPromise.resolve();
   },
 };


### PR DESCRIPTION
This makes serverless-crypt work with wildcard packaging rules like:
```yaml
package:
  exclude:
    - '**/*'
  include:
    - handler.py
```

Mirrors @marcy-terui/serverless-crypt#13